### PR TITLE
Modify: findUserCommentsByUserId API

### DIFF
--- a/src/repositories/comment.repository.ts
+++ b/src/repositories/comment.repository.ts
@@ -47,7 +47,11 @@ export const CommentRepository = dataSource.getRepository(Comment).extend({
   },
 
   async getCommentListByUserId(userId: number, page: Pagination) {
-    let pageCondition = {};
+    let pageCondition: {
+      skip: number;
+      take: number;
+    };
+
     if (page) {
       pageCondition = {
         skip: page.startIndex,
@@ -55,12 +59,57 @@ export const CommentRepository = dataSource.getRepository(Comment).extend({
       };
     }
 
-    return await this.find({
-      withDeleted: true,
-      loadRelationIds: true,
-      where: { user: { id: userId } },
-      order: { created_at: 'DESC' },
-      ...pageCondition,
-    });
+    // version 1 (단순 조회용 : typeORM의 find Option에서는 관계테이블의 세부 내역만을 특정하여 추릴 수 없다.)
+    // return await this.find({
+    //   withDeleted: true,
+    //   loadRelationIds: true,
+    //   where: { user: { id: userId } },
+    //   order: { created_at: 'DESC' },
+    //   ...pageCondition,
+    // });
+
+    // version 2 (로그인한 사용자와의 관계로 비공개 덧글 내용을 조회하기 위한 로직 : 관계 테이블의 세부 정보를 조회하기 위해 queryBuilder를 이용한 join 사용)
+    return await this.createQueryBuilder('comment')
+      .withDeleted()
+      .addSelect('user.id')
+      .addSelect(['feed.id', 'feedUser.id'])
+      .addSelect(['parent.id', 'parentUser.id'])
+      .leftJoin('comment.user', 'user')
+      .leftJoin('comment.feed', 'feed')
+      .leftJoin('feed.user', 'feedUser')
+      .leftJoin('comment.parent', 'parent')
+      .leftJoin('parent.user', 'parentUser')
+      .where('comment.user = :id', { userId })
+      .orderBy('comment.id', 'DESC')
+      .setParameter('id', userId)
+      .skip(pageCondition.skip)
+      .take(pageCondition.take)
+      .getMany();
+
+    // version 3 : version 2에서 응답값을 다중객체가 아닌 하나의 객체로 응답받기 위해 getRawMany() 사용
+    // return await this.createQueryBuilder('comment')
+    //   .withDeleted()
+    //   .select('comment.id', 'id')
+    //   .addSelect('comment.created_at', 'created_at')
+    //   .addSelect('comment.updated_at', 'updated_at')
+    //   .addSelect('comment.deleted_at', 'deleted_at')
+    //   .addSelect('user.id', 'userId')
+    //   .addSelect('feed.id', 'feedId')
+    //   .addSelect('feedUser.id', 'feedUserId')
+    //   .addSelect('comment.comment', 'comment')
+    //   .addSelect('comment.is_private', 'is_private')
+    //   .addSelect('parent.id', 'parentId')
+    //   .addSelect('parentUser.id', 'parentUserId')
+    //   .leftJoin('comment.user', 'user')
+    //   .leftJoin('comment.feed', 'feed')
+    //   .leftJoin('feed.user', 'feedUser')
+    //   .leftJoin('comment.parent', 'parent')
+    //   .leftJoin('parent.user', 'parentUser')
+    //   .where('comment.user = :id', { userId })
+    //   .orderBy('comment.id', 'DESC')
+    //   .setParameter('id', userId)
+    //   .skip(pageCondition.skip)
+    //   .take(pageCondition.take)
+    //   .getRawMany();
   },
 });

--- a/src/services/users.service.ts
+++ b/src/services/users.service.ts
@@ -162,9 +162,13 @@ const findUserCommentsByUserId = async (
   );
 
   for (const comment of userComments) {
-    const isPrivate =
-      comment.is_private === true && comment.user !== loggedInUserId;
-    const isDeleted = comment.deleted_at !== null;
+    const isPrivate: boolean =
+      comment.is_private === true &&
+      comment.user.id !== loggedInUserId &&
+      (comment.parent
+        ? comment.parent.user.id !== loggedInUserId
+        : comment.feed.user.id !== loggedInUserId);
+    const isDeleted: boolean = comment.deleted_at !== null;
     comment.comment = isDeleted
       ? '## DELETED_COMMENT ##'
       : isPrivate


### PR DESCRIPTION
Modify: findUserCommentsByUserId API
  - 로그인한 사용자가 다른 사용자의 댓글 목록 열람시, 본인과 관련된 비공개 댓글은 볼 수 있도록 수정
    - 비공개 댓글의 경우 게시물 작성자는 열람 가능
    - 비공개 대댓글의 경우 원댓글 작성자는 열람가능(게시물 작성자는 열람불가)