### PR TITLE
🍎Chore: updated package dependency 

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "project-review-ts",
-  "version": "1.0.0",
+  "version": "2.0",
   "description": "230118 project start / with front-end : Oh DaWon ",
   "main": "dist/main.js",
   "scripts": {
@@ -79,7 +79,7 @@
     "node": "^16.19.0",
     "nodemailer": "^6.9.1",
     "reflect-metadata": "^0.1.13",
-    "sharp": "^0.31.3",
+    "sharp": "^0.32.6",
     "typeorm": "^0.3.10"
   }
 }

--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
     "@types/bcryptjs": "^2.4.2",
     "@types/cors": "^2.8.12",
     "@types/express": "^4.17.14",
-    "@types/jest": "^29.2.6",
+    "@types/jest": "^29.5.11",
     "@types/jsonwebtoken": "^8.5.9",
     "@types/morgan": "^1.9.3",
     "@types/multer": "^1.4.7",
@@ -53,7 +53,7 @@
     "eslint": "^8.28.0",
     "eslint-config-prettier": "^8.5.0",
     "eslint-plugin-prettier": "^4.2.1",
-    "jest": "^29.3.1",
+    "jest": "^29.7.0",
     "pm2": "^5.3.0",
     "prettier": "2.8.1",
     "supertest": "^6.3.3",
@@ -61,7 +61,7 @@
     "swagger-ui-express": "^4.6.2",
     "ts-jest": "^29.0.5",
     "ts-node": "^10.9.1",
-    "typescript": "^4.8.4"
+    "typescript": "^4.9.5"
   },
   "dependencies": {
     "@aws-sdk/client-lambda": "^3.310.0",
@@ -80,6 +80,6 @@
     "nodemailer": "^6.9.1",
     "reflect-metadata": "^0.1.13",
     "sharp": "^0.32.6",
-    "typeorm": "^0.3.10"
+    "typeorm": "^0.3.19"
   }
 }


### PR DESCRIPTION
- Sharp
  - 이전 버전(0.31.3)의 보안취약성 발견
  - 현재 최신 버전은 0.33.1이지만 현 프로젝트의 Node 16 버전 미호환으로 최적화된 0.32.6 버전으로 패키지 업데이트

- typescript 4.8.4 -> 4.9.5
- typeorm 0.3.10 -> 0.3.19
- jest 29.3.1 -> 29.7.0
- @types/jest 29.2.6 -> 29.5.11